### PR TITLE
Run demo on new typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Cargo.lock
 
 # VSCode
 .vscode
+
+# this project recommends npm
+yarn.lock

--- a/demo/client/src/svg-loader.ts
+++ b/demo/client/src/svg-loader.ts
@@ -107,7 +107,7 @@ export class SVGLoader {
         let time = 0;
         return window.fetch(PARTITION_SVG_PATHS_ENDPOINT_URL, {
             body: JSON.stringify({ paths: paths }),
-            headers: {'Content-Type': 'application/json'},
+            headers: [['Content-Type', 'application/json']],
             method: 'POST',
         }).then(response => {
             time = parseServerTiming(response.headers);

--- a/demo/client/src/text.ts
+++ b/demo/client/src/text.ts
@@ -248,7 +248,7 @@ export class GlyphStore {
         let time = 0;
         return window.fetch(PARTITION_FONT_ENDPOINT_URI, {
             body: JSON.stringify(request),
-            headers: {'Content-Type': 'application/json'},
+            headers: [['Content-Type', 'application/json']],
             method: 'POST',
         }).then(response => {
             time = parseServerTiming(response.headers);


### PR DESCRIPTION
Not a particularly useful PR, but when attempting to run the demo locally the semver bound in package.json allows TypeScript 2.6.1 to be installed, which seems to break the client demo build:

```
ERROR in ./src/text.ts
(251,23): error TS2345: Argument of type '{ body: string; headers: { 'Content-Type': string; }; method: string;}' is not assignable to parameter of type 'RequestInit | undefined'.
  Type '{ body: string; headers: { 'Content-Type': string; }; method: string; }' is not assignable to type 'RequestInit'.
    Types of property 'headers' are incompatible.
      Type '{ 'Content-Type': string; }' is not assignable to type 'Headers | string[][] | undefined'.
        Object literal may only specify known properties, and ''Content-Type'' does not exist in type 'Headers | string[][] | undefined'.

ERROR in ./src/text.ts
(253,17): error TS7006: Parameter 'response' implicitly has an 'any' type.

ERROR in ./src/text.ts
(256,17): error TS7006: Parameter 'buffer' implicitly has an 'any' type.

ERROR in ./src/svg-loader.ts
(110,23): error TS2345: Argument of type '{ body: string; headers: { 'Content-Type': string; }; method: string;}' is not assignable to parameter of type 'RequestInit | undefined'.
  Type '{ body: string; headers: { 'Content-Type': string; }; method: string; }' is not assignable to type 'RequestInit'.
    Types of property 'headers' are incompatible.
      Type '{ 'Content-Type': string; }' is not assignable to type 'Headers | string[][] | undefined'.
        Object literal may only specify known properties, and ''Content-Type'' does not exist in type 'Headers | string[][] | undefined'.

ERROR in ./src/svg-loader.ts
(112,17): error TS7006: Parameter 'response' implicitly has an 'any' type.

ERROR in ./src/svg-loader.ts
(115,17): error TS7006: Parameter 'buffer' implicitly has an 'any' type.
```

I also added yarn.lock to gitignore since the README recommends npm, but would be happy to revert.

I suspect that resolving the TS errors with more accurate type defs might be more reasonable, but this allowed me to run the demo on a fresh clone.