### PR TITLE
chore: use freetype to replace freetype-sys

### DIFF
--- a/font-renderer/Cargo.toml
+++ b/font-renderer/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 
 [features]
 default = []
-freetype = ["freetype-sys"]
+usefreetype = ["freetype"]
 
 [dependencies]
 app_units = "0.5"
@@ -17,12 +17,12 @@ lyon_path = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 
-[dependencies.freetype-sys]
-version = "0.6"
+[dependencies.freetype]
+version = "0.3"
 optional = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-freetype-sys = "0.6"
+freetype = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 

--- a/font-renderer/src/freetype/fixed.rs
+++ b/font-renderer/src/freetype/fixed.rs
@@ -11,7 +11,7 @@
 //! Utilities for FreeType 26.6 fixed-point numbers.
 
 use app_units::Au;
-use freetype_sys::FT_F26Dot6;
+use freetype_sys::freetype::FT_F26Dot6;
 
 pub trait FromFtF26Dot6 {
     fn from_ft_f26dot6(value: FT_F26Dot6) -> Self;

--- a/font-renderer/src/freetype/outline.rs
+++ b/font-renderer/src/freetype/outline.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use euclid::Point2D;
-use freetype_sys::{FT_Outline, FT_Vector};
+use freetype_sys::freetype::{FT_Outline, FT_Vector};
 use lyon_path::iterator::PathIterator;
 use lyon_path::{PathEvent, PathState};
 
@@ -78,7 +78,7 @@ impl<'a> Iterator for OutlineStream<'a> {
                 }
 
                 let last_point_index_in_current_contour =
-                    *self.outline.contours.offset(self.contour_index as isize) as u16; 
+                    *self.outline.contours.offset(self.contour_index as isize) as u16;
                 if self.point_index == last_point_index_in_current_contour + 1 {
                     if let Some(control_point_position) = control_point_position {
                         let event = PathEvent::QuadraticTo(control_point_position,

--- a/font-renderer/src/lib.rs
+++ b/font-renderer/src/lib.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 //! Reads outlines from OpenType fonts into Pathfinder path formats.
-//! 
+//!
 //! Use this crate in conjunction with `pathfinder_partitioner` in order to create meshes for
 //! rendering.
-//! 
+//!
 //! To reduce dependencies and to match the system as closely as possible, this crate uses the
 //! native OS font rendering infrastructure as much as it can. Backends are available for FreeType,
 //! Core Graphics/Quartz on macOS, and DirectWrite on Windows.
@@ -41,7 +41,7 @@ extern crate core_graphics as core_graphics_sys;
 extern crate core_text;
 
 #[cfg(any(target_os = "linux", feature = "freetype"))]
-extern crate freetype_sys;
+extern crate freetype as freetype_sys;
 
 #[cfg(target_os = "windows")]
 extern crate dwrite;
@@ -76,7 +76,7 @@ mod freetype;
 
 /// The number of subpixels that each pixel is divided into for the purposes of subpixel glyph
 /// positioning.
-/// 
+///
 /// Right now, each glyph is snapped to the nearest quarter-pixel.
 pub const SUBPIXEL_GRANULARITY: u8 = 4;
 
@@ -120,7 +120,7 @@ pub struct FontInstance {
     pub font_key: FontKey,
 
     /// The size of the font.
-    /// 
+    ///
     /// This is in app units (1/60 pixels) to eliminate floating point error.
     pub size: Au,
 }
@@ -191,7 +191,7 @@ pub struct GlyphImage {
     /// The dimensions of this image.
     pub dimensions: GlyphDimensions,
     /// The actual pixels.
-    /// 
+    ///
     /// This is 8 bits per pixel grayscale when grayscale antialiasing is in use and 24 bits per
     /// pixel RGB when subpixel antialiasing is in use.
     pub pixels: Vec<u8>,

--- a/utils/frontend/Cargo.toml
+++ b/utils/frontend/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 [dependencies]
 app_units = "0.5"
 clap = "2.27"
-freetype-sys = "0.6"
+freetype = "0.3"
 lyon_geom = "0.9"
 lyon_path = "0.9"
 

--- a/utils/frontend/src/main.rs
+++ b/utils/frontend/src/main.rs
@@ -11,13 +11,13 @@
 //! Pathfinder is built as a set of modular Rust crates and accompanying shaders. Depending on how
 //! you plan to use Pathfinder, you may need to link against many of these crates, or you may not
 //! need to link against any of them and and only use the shaders at runtime.
-//! 
+//!
 //! Typically, if you need to generate paths at runtime or load fonts on the fly, then you will
 //! need to use the `pathfinder_partitioner` and/or `pathfinder_font_renderer` crates. If your app
 //! instead uses a fixed set of paths or fonts, then you may wish to consider running the
 //! Pathfinder command-line tool as part of your build process. Note that in the latter case you
 //! may not need to ship any Rust code at all!
-//! 
+//!
 //! This crate defines the `pathfinder` command line tool. It takes a font as an argument and
 //! produces *mesh libraries* for the glyphs you wish to include. A *mesh library* is essentially a
 //! simple storage format for VBOs. To render these paths, you can directly upload these VBOs to
@@ -25,7 +25,7 @@
 
 extern crate app_units;
 extern crate clap;
-extern crate freetype_sys;
+extern crate freetype as freetype_sys;
 extern crate lyon_geom;
 extern crate lyon_path;
 extern crate pathfinder_font_renderer;
@@ -34,7 +34,8 @@ extern crate pathfinder_path_utils;
 
 use app_units::Au;
 use clap::{App, Arg};
-use freetype_sys::{FT_Init_FreeType, FT_New_Face};
+use freetype_sys::{FT_Error};
+use freetype_sys::freetype::{FT_Init_FreeType, FT_New_Face};
 use lyon_path::PathEvent;
 use lyon_path::builder::{FlatPathBuilder, PathBuilder};
 use pathfinder_font_renderer::{FontContext, FontKey, FontInstance, GlyphKey, SubpixelOffset};
@@ -55,7 +56,7 @@ fn convert_font(font_path: &Path, output_path: &Path) -> Result<(), ()> {
     let mut freetype_library = ptr::null_mut();
     let glyph_count;
     unsafe {
-        if FT_Init_FreeType(&mut freetype_library) != 0 {
+        if FT_Init_FreeType(&mut freetype_library) != FT_Error(0) {
             return Err(())
         }
 
@@ -66,7 +67,7 @@ fn convert_font(font_path: &Path, output_path: &Path) -> Result<(), ()> {
             Some(font_path) => font_path,
         };
         let font_path = try!(CString::new(font_path).map_err(drop));
-        if FT_New_Face(freetype_library, font_path.as_ptr(), 0, &mut freetype_face) != 0 {
+        if FT_New_Face(freetype_library, font_path.as_ptr(), 0, &mut freetype_face) != FT_Error(0) {
             return Err(())
         }
 


### PR DESCRIPTION
I'm trying to build a node canvas with rust: [context_2d](https://github.com/rust-canvas/rust-canvas/blob/feature/font-renderer/src/canvas/context_2d.rs#L121), and borrowed tones of codes from [servo](https://github.com/servo/servo/blob/master/components/canvas/canvas_paint_thread.rs).

When I was trying to built it on linux, it crashed with:

```
error: multiple packages link to native library `freetype`, but a native library can be linked only once

package `servo-freetype-sys v4.0.3`
    ... which is depended on by `azure v0.25.0`
    ... which is depended on by `rustcanvas v0.1.0 (file:///Users/longyinan/workspace/Github/rust-canvas)`
links to native library `freetype`

package `freetype-sys v0.6.0`
    ... which is depended on by `pathfinder_font_renderer v0.1.0 (https://github.com/rust-canvas/pathfinder?branch=rust-canvas#5f082aa4)`
    ... which is depended on by `rustcanvas v0.1.0 (file:///Users/longyinan/workspace/Github/rust-canvas)`
also links to native library `freetype`
```

So I change the dependencies in pathfinder to pass the compile, and I have no idea about the differences between the `freetype-sys` & `freetype`.

Please tell me if you think this Pull Request is unreasonable, and feel free to close it.