### PR TITLE
The Send impl for `FontContext` is too forgiving.

### DIFF
--- a/font-renderer/src/core_graphics.rs
+++ b/font-renderer/src/core_graphics.rs
@@ -56,7 +56,7 @@ pub struct FontContext<FK> where FK: Clone + Hash + Eq + Ord {
 }
 
 // Core Text is thread-safe.
-unsafe impl<FK> Send for FontContext<FK> where FK: Clone + Hash + Eq + Ord {}
+unsafe impl<FK> Send for FontContext<FK> where FK: Clone + Hash + Eq + Ord + Send {}
 
 impl<FK> FontContext<FK> where FK: Clone + Hash + Eq + Ord {
     /// Creates a new font context instance.


### PR DESCRIPTION
I'm pretty confident that it is only thread safe if FK is (or another way of putting it is, I'm pretty sure if you include an `Rc<_>` in FK it should not be safe to share between threads).