### PR TITLE
Super hacky webvr support

### DIFF
--- a/demo/client/html/3d-demo.html.hbs
+++ b/demo/client/html/3d-demo.html.hbs
@@ -42,6 +42,12 @@
                  aria-expanded="false" aria-controls="#pf-settings">
                     <span class="pf-material-icons">settings</span>
                 </button>
+                <button id="pf-vr" type="button"
+                 class="btn btn-outline-secondary pf-toolbar-button"
+                 aria-expanded="false" aria-controls="#pf-vr"
+                 style="display: initial">
+                    <span>VR</span>
+                </button>
             </div>
         </div>
         {{>partials/spinner.html}}

--- a/demo/client/package.json
+++ b/demo/client/package.json
@@ -17,6 +17,7 @@
     "@types/opentype.js": "0.0.0",
     "@types/papaparse": "^4.1.33",
     "@types/webgl-ext": "0.0.29",
+    "@types/webvr-api": "0.0.31",
     "base64-js": "^1.2.3",
     "bootstrap": "^4.0.0",
     "gl-matrix": "^2.4.0",

--- a/demo/client/src/3d-demo.ts
+++ b/demo/client/src/3d-demo.ts
@@ -69,7 +69,7 @@ const AMBIENT_COLOR: glmatrix.vec3 = glmatrix.vec3.clone([0.063, 0.063, 0.063]);
 const DIFFUSE_COLOR: glmatrix.vec3 = glmatrix.vec3.clone([0.356, 0.264, 0.136]);
 const SPECULAR_COLOR: glmatrix.vec3 = glmatrix.vec3.clone([0.490, 0.420, 0.324]);
 
-const MONUMENT_SHININESS: number = 0.0;
+const MONUMENT_SHININESS: number = 32.0;
 
 const CUBE_VERTEX_POSITIONS: Float32Array = new Float32Array([
     -1.0, -1.0, -1.0,  // 0

--- a/demo/client/src/aa-strategy.ts
+++ b/demo/client/src/aa-strategy.ts
@@ -114,7 +114,7 @@ export class NoAAStrategy extends AntialiasingStrategy {
         const renderContext = renderer.renderContext;
         const gl = renderContext.gl;
         gl.bindFramebuffer(gl.FRAMEBUFFER, renderer.destFramebuffer);
-        gl.viewport(0, 0, this.framebufferSize[0], this.framebufferSize[1]);
+        renderer.setDrawViewport();
         gl.disable(gl.SCISSOR_TEST);
     }
 
@@ -125,7 +125,7 @@ export class NoAAStrategy extends AntialiasingStrategy {
         const gl = renderContext.gl;
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, renderer.destFramebuffer);
-        gl.viewport(0, 0, this.framebufferSize[0], this.framebufferSize[1]);
+        renderer.setDrawViewport();
         gl.disable(gl.SCISSOR_TEST);
     }
 

--- a/demo/client/src/app-controller.ts
+++ b/demo/client/src/app-controller.ts
@@ -175,6 +175,16 @@ export abstract class DemoAppController<View extends DemoView> extends AppContro
             }, false);
         }
 
+        const vrButton = document.getElementById('pf-vr') as HTMLInputElement |
+            null;
+        if (vrButton != null) {
+            vrButton.addEventListener('click', event => {
+                this.view.then(view => {
+                    view.enterVR();
+                });
+            }, false);
+        }
+
         this.filePickerView = FilePickerView.create();
         if (this.filePickerView != null) {
             this.filePickerView.onFileLoaded = fileData => this.fileLoaded(fileData, null);

--- a/demo/client/src/camera.ts
+++ b/demo/client/src/camera.ts
@@ -325,6 +325,8 @@ export class PerspectiveCamera extends Camera {
 
     private readonly innerCollisionExtent: number;
 
+    private vrRotationMatrix: glmatrix.mat4 | null;
+
     constructor(canvas: HTMLCanvasElement, options?: PerspectiveCameraOptions) {
         super(canvas);
 
@@ -345,6 +347,7 @@ export class PerspectiveCamera extends Camera {
         window.addEventListener('keyup', event => this.onKeyUp(event), false);
 
         this.onChange = null;
+        this.vrRotationMatrix = null;
 
         this.wasdPress = _.fromPairs([
             ['W'.charCodeAt(0), false],
@@ -368,6 +371,10 @@ export class PerspectiveCamera extends Camera {
 
     rotate(newAngle: number): void {
         // TODO(pcwalton)
+    }
+
+    setView(rotation: glmatrix.mat4, pose: VRPose) {
+        this.vrRotationMatrix = rotation;
     }
 
     private onMouseDown(event: MouseEvent): void {
@@ -487,6 +494,9 @@ export class PerspectiveCamera extends Camera {
     }
 
     get rotationMatrix(): glmatrix.mat4 {
+        if (this.vrRotationMatrix != null) {
+            return this.vrRotationMatrix;
+        }
         const matrix = glmatrix.mat4.create();
         glmatrix.mat4.fromXRotation(matrix, this.rotation[1]);
         glmatrix.mat4.rotateY(matrix, matrix, this.rotation[0]);

--- a/demo/client/src/renderer.ts
+++ b/demo/client/src/renderer.ts
@@ -133,6 +133,10 @@ export abstract class Renderer {
     abstract pathBoundingRects(objectIndex: number): Float32Array;
     abstract setHintsUniform(uniforms: UniformMap): void;
 
+    redrawVR(frame: VRFrameData): void {
+        this.redraw();
+    }
+
     redraw(): void {
         const renderContext = this.renderContext;
 
@@ -141,11 +145,6 @@ export abstract class Renderer {
 
         this.clearDestFramebuffer();
 
-        // Start timing rendering.
-        if (this.timerQueryPollInterval == null) {
-            renderContext.timerQueryExt.beginQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT,
-                                                      renderContext.atlasRenderingTimerQuery);
-        }
 
         const antialiasingStrategy = unwrapNull(this.antialiasingStrategy);
         antialiasingStrategy.prepareForRendering(this);
@@ -178,11 +177,6 @@ export abstract class Renderer {
                 // FIXME(pcwalton): This is kinda bogus for multipass.
                 if (this.timerQueryPollInterval == null && objectIndex === objectCount - 1 &&
                     pass === passCount - 1) {
-                    renderContext.timerQueryExt
-                                 .endQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT);
-                    renderContext.timerQueryExt
-                                .beginQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT,
-                                                renderContext.compositingTimerQuery);
                 }
 
                 // Perform post-antialiasing tasks.
@@ -575,28 +569,13 @@ export abstract class Renderer {
         if (this.timerQueryPollInterval != null)
             return;
 
-        renderContext.timerQueryExt.endQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT);
+        // renderContext.timerQueryExt.endQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT);
 
         this.timerQueryPollInterval = window.setInterval(() => {
-            for (const queryName of ['atlasRenderingTimerQuery', 'compositingTimerQuery'] as
-                    Array<'atlasRenderingTimerQuery' | 'compositingTimerQuery'>) {
-                if (renderContext.timerQueryExt
-                                 .getQueryObjectEXT(renderContext[queryName],
-                                                    renderContext.timerQueryExt
-                                                                 .QUERY_RESULT_AVAILABLE_EXT) ===
-                        0) {
-                    return;
-                }
-            }
 
-            const atlasRenderingTime =
-                renderContext.timerQueryExt
-                             .getQueryObjectEXT(renderContext.atlasRenderingTimerQuery,
-                                                renderContext.timerQueryExt.QUERY_RESULT_EXT);
-            const compositingTime =
-                renderContext.timerQueryExt
-                             .getQueryObjectEXT(renderContext.compositingTimerQuery,
-                                                renderContext.timerQueryExt.QUERY_RESULT_EXT);
+
+            const atlasRenderingTime = 1;
+            const compositingTime = 1;
             this.lastTimings = {
                 compositing: compositingTime / 1000000.0,
                 rendering: atlasRenderingTime / 1000000.0,

--- a/demo/client/src/renderer.ts
+++ b/demo/client/src/renderer.ts
@@ -137,14 +137,25 @@ export abstract class Renderer {
         this.redraw();
     }
 
+    enterVR() {
+        if (this.antialiasingStrategy != null) {
+            this.antialiasingStrategy.setFramebufferSize(this);
+        }
+    }
+
+    setDrawViewport() {
+        const renderContext = this.renderContext;
+        const gl = renderContext.gl;
+        gl.viewport(0, 0, this.destAllocatedSize[0], this.destAllocatedSize[1]);
+    }
+
     redraw(): void {
         const renderContext = this.renderContext;
 
         if (this.meshBuffers == null)
             return;
 
-        this.clearDestFramebuffer();
-
+        this.clearDestFramebuffer(false);
 
         const antialiasingStrategy = unwrapNull(this.antialiasingStrategy);
         antialiasingStrategy.prepareForRendering(this);
@@ -393,7 +404,7 @@ export abstract class Renderer {
 
     protected drawSceneryIfNecessary(): void {}
 
-    protected clearDestFramebuffer(): void {
+    protected clearDestFramebuffer(force: boolean): void {
         const renderContext = this.renderContext;
         const gl = renderContext.gl;
 
@@ -572,7 +583,6 @@ export abstract class Renderer {
         // renderContext.timerQueryExt.endQueryEXT(renderContext.timerQueryExt.TIME_ELAPSED_EXT);
 
         this.timerQueryPollInterval = window.setInterval(() => {
-
 
             const atlasRenderingTime = 1;
             const compositingTime = 1;

--- a/demo/client/src/ssaa-strategy.ts
+++ b/demo/client/src/ssaa-strategy.ts
@@ -128,7 +128,7 @@ export default class SSAAStrategy extends AntialiasingStrategy {
         const gl = renderContext.gl;
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, renderer.destFramebuffer);
-        gl.viewport(0, 0, renderer.destAllocatedSize[0], renderer.destAllocatedSize[1]);
+        renderer.setDrawViewport();
         gl.disable(gl.DEPTH_TEST);
         gl.disable(gl.BLEND);
 

--- a/demo/client/src/view.ts
+++ b/demo/client/src/view.ts
@@ -21,6 +21,7 @@ import {Renderer} from './renderer';
 import {PathfinderShaderProgram, SHADER_NAMES, ShaderMap} from './shader-loader';
 import {ShaderProgramSource, UnlinkedShaderProgram} from './shader-loader';
 import {expectNotNull, PathfinderError, UINT32_SIZE, unwrapNull} from './utils';
+import {NEAR_CLIP_PLANE, FAR_CLIP_PLANE} from './3d-demo';
 
 const QUAD_POSITIONS: Float32Array = new Float32Array([
     0.0, 0.0,
@@ -154,8 +155,6 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
     quadTexCoordsBuffer!: WebGLBuffer;
     quadElementsBuffer!: WebGLBuffer;
 
-    atlasRenderingTimerQuery!: WebGLQuery;
-    compositingTimerQuery!: WebGLQuery;
 
     meshes: PathfinderPackedMeshBuffers[];
     meshData: PathfinderPackedMeshes[];
@@ -173,6 +172,9 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
     protected colorBufferHalfFloatExt: any;
 
     private wantsScreenshot: boolean;
+    private vrDisplay: VRDisplay | null;
+    private vrFrameData: VRFrameData | null;
+    private inVrRAF: boolean;
 
     /// NB: All subclasses are responsible for creating a renderer in their constructors.
     constructor(gammaLUT: HTMLImageElement,
@@ -191,6 +193,14 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
         this.gammaLUT = gammaLUT;
 
         this.wantsScreenshot = false;
+        this.vrDisplay = null;
+        if ("VRFrameData" in window) {
+           this.vrFrameData = new VRFrameData;
+        } else {
+            this.vrFrameData = null;
+        }
+        
+        this.inVrRAF = false;
     }
 
     attachMeshes(meshes: PathfinderPackedMeshes[]): void {
@@ -242,13 +252,59 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
         return buffer;
     }
 
+    enterVR(): void {
+        if (this.vrDisplay != null) {
+            this.vrDisplay.requestPresent([{ source: this.canvas }]);
+            const that = this;
+            function vrCallback(): void {
+                if (that.vrDisplay == null) {
+                    return;
+                }
+                that.vrDisplay.requestAnimationFrame(vrCallback);
+                that.inVrRAF = true;
+                that.redraw();
+                that.inVrRAF = false;
+            }
+            this.vrDisplay.requestAnimationFrame(vrCallback);
+        }
+        if (navigator.getVRDisplays) {
+            navigator.getVRDisplays().then((displays) => {
+              if (displays.length > 0) {
+                this.vrDisplay = displays[displays.length - 1];
+
+                // It's heighly reccommended that you set the near and far planes to
+                // something appropriate for your scene so the projection matricies
+                // WebVR produces have a well scaled depth buffer.
+                this.vrDisplay.depthNear = NEAR_CLIP_PLANE;
+                this.vrDisplay.depthFar = FAR_CLIP_PLANE;
+              } else {
+                alert("Your device has no VR displays")
+              }
+            }, function () {
+              alert("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
+            });
+        } else {
+            alert("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
+        }
+    }
+
     redraw(): void {
         super.redraw();
 
         if (!this.renderer.meshesAttached)
             return;
 
-        this.renderer.redraw();
+        if (this.vrDisplay == null || this.vrFrameData == null) {
+            this.renderer.redraw();
+        } else {
+            if (!this.inVrRAF) {
+                console.log("redraw() called outside of vr RAF, will get drawn later");
+                return;
+            }
+            this.vrDisplay.getFrameData(this.vrFrameData);
+            this.renderer.redrawVR(this.vrFrameData);
+            this.vrDisplay.submitFrame()
+        }
 
         // Invoke the post-render hook.
         this.renderingFinished();
@@ -274,7 +330,7 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
         this.textureHalfFloatExt = unwrapNull(this.gl.getExtension('OES_texture_half_float'));
         this.timerQueryExt = this.gl.getExtension('EXT_disjoint_timer_query');
         this.vertexArrayObjectExt = unwrapNull(this.gl.getExtension('OES_vertex_array_object'));
-        this.gl.getExtension('EXT_frag_depth');
+        // this.gl.getExtension('EXT_frag_depth');
         this.gl.getExtension('OES_element_index_uint');
         this.gl.getExtension('OES_standard_derivatives');
         this.gl.getExtension('OES_texture_float');
@@ -291,9 +347,6 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
         this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.quadElementsBuffer);
         this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, QUAD_ELEMENTS, this.gl.STATIC_DRAW);
 
-        // Set up our timer queries for profiling.
-        this.atlasRenderingTimerQuery = this.timerQueryExt.createQueryEXT();
-        this.compositingTimerQuery = this.timerQueryExt.createQueryEXT();
     }
 
     protected renderingFinished(): void {}
@@ -376,9 +429,6 @@ export interface RenderContext {
 
     readonly quadPositionsBuffer: WebGLBuffer;
     readonly quadElementsBuffer: WebGLBuffer;
-
-    readonly atlasRenderingTimerQuery: WebGLQuery;
-    readonly compositingTimerQuery: WebGLQuery;
 
     initQuadVAO(attributes: any): void;
     setDirty(): void;

--- a/demo/client/src/view.ts
+++ b/demo/client/src/view.ts
@@ -261,6 +261,8 @@ export abstract class DemoView extends PathfinderView implements RenderContext {
                     return;
                 }
                 that.vrDisplay.requestAnimationFrame(vrCallback);
+
+                that.renderer.enterVR();
                 that.inVrRAF = true;
                 that.redraw();
                 that.inVrRAF = false;

--- a/demo/client/src/xcaa-strategy.ts
+++ b/demo/client/src/xcaa-strategy.ts
@@ -296,7 +296,7 @@ export abstract class XCAAStrategy extends AntialiasingStrategy {
         const gl = renderContext.gl;
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, renderer.destFramebuffer);
-        gl.viewport(0, 0, this.destFramebufferSize[0], this.destFramebufferSize[1]);
+        renderer.setDrawViewport();
         gl.disable(gl.SCISSOR_TEST);
     }
 

--- a/demo/client/tsconfig.json
+++ b/demo/client/tsconfig.json
@@ -8,7 +8,8 @@
             "lodash",
             "node",
             "opentype.js",
-            "webgl-ext"
+            "webgl-ext",
+            "webvr-api"
         ],
         "typeRoots": [
             "node_modules/@types"

--- a/shaders/gles2/common.inc.glsl
+++ b/shaders/gles2/common.inc.glsl
@@ -10,7 +10,7 @@
 
 #version 100
 
-#extension GL_EXT_frag_depth : require
+// #extension GL_EXT_frag_depth : require
 #extension GL_OES_standard_derivatives : require
 
 #define LCD_FILTER_FACTOR_0     (86.0 / 255.0)

--- a/shaders/gles2/demo-3d-monument.fs.glsl
+++ b/shaders/gles2/demo-3d-monument.fs.glsl
@@ -32,15 +32,7 @@ void main() {
     vec3 lightDirection = normalize(uLightPosition - vPosition);
 
     float lambertian = max(dot(lightDirection, normal), 0.0);
-    float specular = 0.0;
 
-    if (lambertian > 0.0) {
-        vec3 viewDirection = normalize(-vPosition);
-        vec3 halfDirection = normalize(lightDirection + viewDirection);
-        float specularAngle = max(dot(halfDirection, normal), 0.0);
-        specular = pow(specularAngle, uShininess);
-    }
-
-    vec3 color = uAmbientColor + lambertian * uDiffuseColor + specular * uSpecularColor;
+    vec3 color = uAmbientColor /*+ lambertian * uDiffuseColor*/;
     gl_FragColor = vec4(color, 1.0);
 }


### PR DESCRIPTION
don't merge this, it breaks a bunch of things.

To use:

 - Open the 3d demo in Chrome Canary for Android with webvr enabled (chrome://flags)
 - Select an AA strategy _other_ than 4xSSAA (this hits memory limits and needs investigation)
 - Click the VR button _twice_ . This is due to a bug in how chrome determines if a VR request was initiated by user action
 - Put the phone in your Daydream and press the home key on your controller
 - Connect a physical keyboard to navigate. Yes, really.


The AA breaks down at a distance and shows fuzzy stuff, so you'll need to move closer to the monument to see text.


Will work on a proper mergeable PR later.