### PR TITLE
Use servo-freetype instead of the system-native freetype

### DIFF
--- a/font-renderer/Cargo.toml
+++ b/font-renderer/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 
 [features]
 default = []
-freetype = ["freetype-sys"]
+freetype-feature = ["freetype-sys"]
 
 [dependencies]
 app_units = "0.6"
@@ -21,11 +21,11 @@ version = "0.17"
 features = ["serde"]
 
 [dependencies.freetype-sys]
-version = "0.6"
+version = "0.4"
 optional = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-freetype-sys = "0.6"
+freetype = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.13"

--- a/font-renderer/src/freetype/fixed.rs
+++ b/font-renderer/src/freetype/fixed.rs
@@ -11,7 +11,7 @@
 //! Utilities for FreeType 26.6 fixed-point numbers.
 
 use app_units::Au;
-use freetype_sys::FT_F26Dot6;
+use freetype_crate::freetype::FT_F26Dot6;
 
 pub trait FromFtF26Dot6 {
     fn from_ft_f26dot6(value: FT_F26Dot6) -> Self;

--- a/font-renderer/src/freetype/mod.rs
+++ b/font-renderer/src/freetype/mod.rs
@@ -11,12 +11,12 @@
 //! Font loading using FreeType.
 
 use euclid::{Point2D, Size2D, Vector2D};
-use freetype_sys::{FT_BBox, FT_Bitmap, FT_Done_Face, FT_F26Dot6, FT_Face, FT_GLYPH_FORMAT_OUTLINE};
-use freetype_sys::{FT_GlyphSlot, FT_Init_FreeType, FT_Int32, FT_LCD_FILTER_DEFAULT};
-use freetype_sys::{FT_LOAD_NO_HINTING, FT_Library, FT_Library_SetLcdFilter};
-use freetype_sys::{FT_Load_Glyph, FT_Long, FT_New_Memory_Face, FT_Outline_Get_CBox};
-use freetype_sys::{FT_Outline_Translate, FT_PIXEL_MODE_LCD, FT_RENDER_MODE_LCD, FT_Render_Glyph};
-use freetype_sys::{FT_Set_Char_Size, FT_UInt};
+use freetype_crate::freetype::{FT_BBox, FT_Bitmap, FT_Done_Face, FT_F26Dot6, FT_Face};
+use freetype_crate::freetype::{FT_GlyphSlot, FT_Init_FreeType, FT_Int32};
+use freetype_crate::freetype::{FT_LOAD_NO_HINTING, FT_Library, FT_Library_SetLcdFilter};
+use freetype_crate::freetype::{FT_Load_Glyph, FT_Long, FT_New_Memory_Face, FT_Outline_Get_CBox};
+use freetype_crate::freetype::{FT_Outline_Translate, FT_Render_Glyph};
+use freetype_crate::freetype::{FT_Set_Char_Size, FT_UInt};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::hash::Hash;
@@ -24,6 +24,11 @@ use std::mem;
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
+
+use freetype_crate::freetype::FT_Glyph_Format;
+use freetype_crate::freetype::FT_LcdFilter;
+use freetype_crate::freetype::FT_Pixel_Mode;
+use freetype_crate::freetype::FT_Render_Mode;
 
 use self::fixed::{FromFtF26Dot6, ToFtF26Dot6};
 use self::outline::Outline;
@@ -37,7 +42,7 @@ pub type GlyphOutline<'a> = Outline<'a>;
 // Default to no hinting.
 //
 // TODO(pcwalton): Make this configurable.
-const GLYPH_LOAD_FLAGS: FT_Int32 = FT_LOAD_NO_HINTING;
+const GLYPH_LOAD_FLAGS: FT_Int32 = FT_LOAD_NO_HINTING as FT_Int32;
 
 const DPI: u32 = 72;
 
@@ -173,14 +178,14 @@ impl<FK> FontContext<FK> where FK: Clone + Hash + Eq + Ord {
         //
         // TODO(pcwalton): Non-subpixel AA.
         unsafe {
-            FT_Library_SetLcdFilter(self.library, FT_LCD_FILTER_DEFAULT);
+            FT_Library_SetLcdFilter(self.library, FT_LcdFilter::FT_LCD_FILTER_DEFAULT);
         }
 
         // Render the glyph.
         //
         // TODO(pcwalton): Non-subpixel AA.
         unsafe {
-            FT_Render_Glyph(slot, FT_RENDER_MODE_LCD);
+            FT_Render_Glyph(slot, FT_Render_Mode::FT_RENDER_MODE_LCD);
         }
 
         unsafe {
@@ -188,7 +193,7 @@ impl<FK> FontContext<FK> where FK: Clone + Hash + Eq + Ord {
             //
             // TODO(pcwalton): Non-subpixel AA.
             let bitmap: *const FT_Bitmap = &(*slot).bitmap;
-            if (*bitmap).pixel_mode as u32 != FT_PIXEL_MODE_LCD {
+            if (*bitmap).pixel_mode as u32 != FT_Pixel_Mode::FT_PIXEL_MODE_LCD as u32 {
                 return Err(())
             }
 
@@ -244,7 +249,7 @@ impl<FK> FontContext<FK> where FK: Clone + Hash + Eq + Ord {
             }
 
             let slot = (*face.face).glyph;
-            if (*slot).format != FT_GLYPH_FORMAT_OUTLINE {
+            if (*slot).format != FT_Glyph_Format::FT_GLYPH_FORMAT_OUTLINE {
                 return None
             }
 

--- a/font-renderer/src/freetype/outline.rs
+++ b/font-renderer/src/freetype/outline.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use euclid::Point2D;
-use freetype_sys::{FT_Outline, FT_Vector};
+use freetype_crate::freetype::{FT_Outline, FT_Vector};
 use lyon_path::iterator::PathIterator;
 use lyon_path::{PathEvent, PathState};
 

--- a/font-renderer/src/lib.rs
+++ b/font-renderer/src/lib.rs
@@ -40,8 +40,8 @@ extern crate core_graphics as core_graphics_sys;
 #[cfg(target_os = "macos")]
 extern crate core_text;
 
-#[cfg(any(target_os = "linux", feature = "freetype"))]
-extern crate freetype_sys;
+#[cfg(any(target_os = "linux", feature = "freetype-feature"))]
+extern crate freetype as freetype_crate;
 
 #[cfg(target_os = "windows")]
 extern crate dwrite;
@@ -63,7 +63,7 @@ mod tests;
 pub use core_graphics::{FontContext, GlyphOutline};
 #[cfg(all(target_os = "windows", not(feature = "freetype")))]
 pub use directwrite::FontContext;
-#[cfg(any(target_os = "linux", feature = "freetype"))]
+#[cfg(any(target_os = "linux", feature = "freetype-feature"))]
 pub use freetype::FontContext;
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
See https://github.com/servo/webrender/issues/2617

It seems that `freetype-sys`, which is what pathfinder uses, links to the system-native freetype version, i.e. whatever you happen to have installed right now. webrender, on the other hand, uses `freetype`, which is the `servo-freetype` version, which embeds a full copy of freetype into the binary. This also means that pathfinder shouldn't build on linux if you don't have freetype installed.

I had to rename a few things, because a feature, a module and a crate that are all named "freetype" led to naming conflicts. 