### PR TITLE
Fix the API of glyph_dimensions to make webrender compile on Windows

### DIFF
--- a/font-renderer/src/directwrite/mod.rs
+++ b/font-renderer/src/directwrite/mod.rs
@@ -22,6 +22,7 @@ use std::iter::Cloned;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
+use std::collections::btree_map::Entry;
 use std::slice::{self, Iter};
 use std::sync::Arc;
 use uuid::IID_ID2D1SimplifiedGeometrySink;
@@ -36,7 +37,8 @@ use winapi::{IDWriteFontFileLoader, IDWriteFontFileLoaderVtbl, IDWriteFontFileSt
 use winapi::{IDWriteFontFileStreamVtbl, IDWriteGeometrySink, IUnknown, IUnknownVtbl, TRUE, UINT16};
 use winapi::{UINT32, UINT64, UINT};
 
-use self::com::{PathfinderCoclass, PathfinderComObject, PathfinderComPtr};
+use self::com::{PathfinderCoclass, PathfinderComObject};
+pub use self::com::{PathfinderComPtr};
 use {FontInstance, GlyphDimensions, GlyphImage, GlyphKey};
 
 mod com;
@@ -175,6 +177,19 @@ impl<FK> FontContext<FK> where FK: Clone + Hash + Eq + Ord {
 
             self.dwrite_font_faces.insert((*font_key).clone(), font_face);
             Ok(())
+        }
+    }
+
+    /// Loads an OpenType font from a COM `IDWriteFontFace` handle.
+    pub fn add_native_font<H>(&mut self, font_key: &FK, handle: H) -> Result<(), ()> 
+                        where H: Into<PathfinderComPtr<IDWriteFontFace>>
+    {
+        match self.dwrite_font_faces.entry((*font_key).clone()) {
+            Entry::Occupied(_) => Ok(()),
+            Entry::Vacant(entry) => {
+                entry.insert(handle.into());
+                Ok(())
+            }
         }
     }
 

--- a/font-renderer/src/lib.rs
+++ b/font-renderer/src/lib.rs
@@ -53,6 +53,11 @@ extern crate uuid;
 #[macro_use(DEFINE_GUID)]
 extern crate winapi;
 
+#[cfg(target_os = "windows")]
+pub use self::directwrite::PathfinderComPtr;
+#[cfg(target_os = "windows")]
+pub use winapi::IDWriteFontFace;
+
 use app_units::Au;
 use euclid::{Point2D, Size2D};
 


### PR DESCRIPTION
See https://github.com/servo/webrender/issues/2645 - this fixes 2 of the 6 errors I get when compiling webrender on Windows. 

I decided to use the same API that is used for Mac & Linux builds, with the extra `exact` parameter and returning an Error instead of an Option. Maybe it would be a good idea to change it back to `Option` instead of `Err<()>`, but then please change it in all 3 APIs. 