### PR TITLE
Outline tags are chars not i8s

### DIFF
--- a/font-renderer/src/freetype/outline.rs
+++ b/font-renderer/src/freetype/outline.rs
@@ -10,10 +10,11 @@
 
 use euclid::Point2D;
 use freetype_sys::freetype::{FT_Outline, FT_Vector};
+use libc::c_char;
 use lyon_path::iterator::PathIterator;
 use lyon_path::{PathEvent, PathState};
 
-const FREETYPE_POINT_ON_CURVE: i8 = 0x01;
+const FREETYPE_POINT_ON_CURVE: c_char = 0x01;
 
 #[derive(Clone)]
 pub struct Outline<'a> {
@@ -57,7 +58,7 @@ impl<'a> OutlineStream<'a> {
     }
 
     #[inline]
-    fn current_position_and_tag(&self) -> (Point2D<f32>, i8) {
+    fn current_position_and_tag(&self) -> (Point2D<f32>, c_char) {
         unsafe {
             let point_offset = self.point_index as isize;
             let position = ft_vector_to_f32(*self.outline.points.offset(point_offset));


### PR DESCRIPTION
In `font-renderer/src/freetype/outline.rs` there's an assumption that `c_char` is `i8`, so it fails to compile on architectures where `c_char` is `u8`:
```
info: component 'rust-std' for target 'aarch64-linux-android' is up to date
   Compiling pathfinder_font_renderer v0.5.0 (/Users/ajeffrey/github/asajeffrey/pathfinder/font-renderer)
   Compiling script_layout_interface v0.0.1 (/Users/ajeffrey/github/asajeffrey/servo/components/script_layout_interface)
   Compiling layout_traits v0.0.1 (/Users/ajeffrey/github/asajeffrey/servo/components/layout_traits)
error[E0308]: mismatched types
  --> /Users/ajeffrey/github/asajeffrey/pathfinder/font-renderer/src/freetype/outline.rs:65:24
   |
65 |             (position, tag)
   |                        ^^^ expected i8, found u8

error: aborting due to previous error
```