### PR TITLE
Allow a non-zero default framebuffer

### DIFF
--- a/demo/common/src/lib.rs
+++ b/demo/common/src/lib.rs
@@ -112,7 +112,7 @@ impl<W> DemoApp<W> where W: Window {
     pub fn new(window: W, window_size: WindowSize) -> DemoApp<W> {
         let expire_message_event_id = window.create_user_event_id();
 
-        let device = GLDevice::new(window.gl_version());
+        let device = GLDevice::new(window.gl_version(), window.gl_default_framebuffer());
         let resources = window.resource_loader();
         let options = Options::get();
 

--- a/demo/common/src/window.rs
+++ b/demo/common/src/window.rs
@@ -10,6 +10,7 @@
 
 //! A minimal cross-platform windowing layer.
 
+use gl::types::GLuint;
 use pathfinder_geometry::basic::point::Point2DI32;
 use pathfinder_geometry::distortion::BarrelDistortionCoefficients;
 use pathfinder_gl::GLVersion;
@@ -18,6 +19,7 @@ use std::path::PathBuf;
 
 pub trait Window {
     fn gl_version(&self) -> GLVersion;
+    fn gl_default_framebuffer(&self) -> GLuint { 0 }
     fn mouse_position(&self) -> Point2DI32;
     fn present(&self);
     fn resource_loader(&self) -> &dyn ResourceLoader;

--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -24,15 +24,18 @@ use std::mem;
 use std::ptr;
 use std::str;
 use std::time::Duration;
-
 pub struct GLDevice {
     version: GLVersion,
+    default_framebuffer: GLuint,
 }
 
 impl GLDevice {
     #[inline]
-    pub fn new(version: GLVersion) -> GLDevice {
-        GLDevice { version }
+    pub fn new(version: GLVersion, default_framebuffer: GLuint) -> GLDevice {
+        GLDevice {
+            version,
+            default_framebuffer,
+        }
     }
 
     fn set_texture_parameters(&self, texture: &GLTexture) {
@@ -455,7 +458,7 @@ impl Device for GLDevice {
     fn read_pixels_from_default_framebuffer(&self, size: Point2DI32) -> Vec<u8> {
         let mut pixels = vec![0; size.x() as usize * size.y() as usize * 4];
         unsafe {
-            gl::BindFramebuffer(gl::FRAMEBUFFER, 0); ck();
+            gl::BindFramebuffer(gl::FRAMEBUFFER, self.default_framebuffer); ck();
             gl::ReadPixels(0,
                            0,
                            size.x() as GLsizei,
@@ -594,7 +597,7 @@ impl Device for GLDevice {
     #[inline]
     fn bind_default_framebuffer(&self, viewport: RectI32) {
         unsafe {
-            gl::BindFramebuffer(gl::FRAMEBUFFER, 0); ck();
+            gl::BindFramebuffer(gl::FRAMEBUFFER, self.default_framebuffer); ck();
             gl::Viewport(viewport.origin().x(),
                          viewport.origin().y(),
                          viewport.size().x(),


### PR DESCRIPTION
Allows using pathfinder when the default framebuffer is non-zero (e.g. on ML1).