### PR TITLE
In the demo, handle events before updating the scene

### DIFF
--- a/demo/common/src/lib.rs
+++ b/demo/common/src/lib.rs
@@ -184,11 +184,11 @@ impl<W> DemoApp<W> where W: Window {
     }
 
     pub fn prepare_frame(&mut self, events: Vec<Event>) -> u32 {
-        // Update the scene.
-        self.build_scene();
-
         // Handle events.
         let ui_events = self.handle_events(events);
+
+        // Update the scene.
+        self.build_scene();
 
         // Get the render message, and determine how many scenes it contains.
         let render_msg = self.scene_thread_proxy.receiver.recv().unwrap();


### PR DESCRIPTION
This gets rid of one frame of latency when there are events (e.g. pose data in VR) which affect the scene.