### PR TITLE
Made BackgroundColor public

### DIFF
--- a/demo/common/src/lib.rs
+++ b/demo/common/src/lib.rs
@@ -11,7 +11,7 @@
 //! A demo app for Pathfinder.
 
 use crate::device::{GroundLineVertexArray, GroundProgram, GroundSolidVertexArray};
-use crate::ui::{BackgroundColor, DemoUI, UIAction};
+use crate::ui::{DemoUI, UIAction};
 use crate::window::{Event, Keycode, SVGPath, Window, WindowSize};
 use clap::{App, Arg};
 use image::ColorType;
@@ -46,6 +46,8 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 use usvg::{Options as UsvgOptions, Tree};
+
+pub use ui::BackgroundColor;
 
 static DEFAULT_SVG_VIRTUAL_PATH: &'static str = "svg/Ghostscript_Tiger.svg";
 


### PR DESCRIPTION
Trying to use `BackgroundColor` outside `pathfinder_demo` results in:

```
error[E0603]: enum `BackgroundColor` is private
  --> demo/magicleap/src/lib.rs:28:22
   |
28 | use pathfinder_demo::BackgroundColor;
   |                      ^^^^^^^^^^^^^^^
```
or
```
error[E0603]: module `ui` is private
  --> demo/magicleap/src/lib.rs:28:22
   |
28 | use pathfinder_demo::ui::BackgroundColor;
   |                      ^^
```
