### PR TITLE
[WIP] Recycle vectors in assembly thread

### DIFF
--- a/renderer/src/builder.rs
+++ b/renderer/src/builder.rs
@@ -158,12 +158,15 @@ impl SceneAssemblyThread {
             match msg {
                 MainToSceneAssemblyMsg::Exit => break,
                 MainToSceneAssemblyMsg::NewScene { listener, effective_view_box, z_buffer } => {
-                    let current_pass = Pass {
+                    let mut current_pass = Pass {
                         alpha_tiles: self.alpha_tile_pool.pop().unwrap_or_else(Vec::new),
                         solid_tiles: self.solid_tile_pool.pop().unwrap_or_else(Vec::new),
                         fills: self.fill_pool.pop().unwrap_or_else(Vec::new),
                         object_range: 0..0,
                     };
+                    current_pass.alpha_tiles.clear();
+                    current_pass.solid_tiles.clear();
+                    current_pass.fills.clear();
                     self.info = Some(SceneAssemblyThreadInfo {
                         listener,
                         built_object_queue: SortedVector::new(),

--- a/renderer/src/gpu_data.rs
+++ b/renderer/src/gpu_data.rs
@@ -20,6 +20,7 @@ use pathfinder_geometry::util;
 use pathfinder_simd::default::{F32x4, I32x4};
 use std::fmt::{Debug, Formatter, Result as DebugResult};
 use std::ops::Add;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct BuiltObject {
@@ -40,9 +41,9 @@ pub struct BuiltScene {
 
 pub enum RenderCommand {
     ClearMaskFramebuffer,
-    Fill(Vec<FillBatchPrimitive>),
-    AlphaTile(Vec<AlphaTileBatchPrimitive>),
-    SolidTile(Vec<SolidTileBatchPrimitive>),
+    Fill(Arc<Vec<FillBatchPrimitive>>),
+    AlphaTile(Arc<Vec<AlphaTileBatchPrimitive>>),
+    SolidTile(Arc<Vec<SolidTileBatchPrimitive>>),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This change removes most of the calls into jemalloc from the assembly thread. Without it, we were spending ~30% of CPU time in the allocator.