### PR TITLE
Fix vertex attribute configuration of alpha tiles

### DIFF
--- a/renderer/src/gpu/renderer.rs
+++ b/renderer/src/gpu/renderer.rs
@@ -1034,7 +1034,7 @@ where
         );
         device.configure_int_vertex_attr(
             &object_attr,
-            2,
+            1,
             VertexAttrType::I16,
             MASK_TILE_INSTANCE_SIZE,
             4,
@@ -1042,7 +1042,7 @@ where
         );
         device.configure_int_vertex_attr(
             &tile_index_attr,
-            2,
+            1,
             VertexAttrType::I16,
             MASK_TILE_INSTANCE_SIZE,
             6,


### PR DESCRIPTION
Fixes #134.

glVertexAttribPointer takes a size as parameter which refers to the number of components and not the size in bytes of the value.
The tile index was registered as a 2-components value which caused the second component to overlap with the first member of the next primitive, which was mostly fine except for the last element which would overlfow the buffer. Intel and nvidia GPUs/drivers on linux at least refuse to read the first component of this two-component value if the other component is outside of the valid range which caused the shader to get zero instead and always select the first mask tile.