### PR TITLE
Silence unused variable warning

### DIFF
--- a/simd/src/scalar/mod.rs
+++ b/simd/src/scalar/mod.rs
@@ -175,7 +175,7 @@ impl F32x4 {
     }
 
     #[inline]
-    pub fn cross(&self, other: F32x4) -> F32x4 {
+    pub fn cross(&self, _other: F32x4) -> F32x4 {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Silencing the following rustc warning:
warning: unused variable: `other`

Small fix but I want to contribute more if you are OK with it 😄 