### PR TITLE
Add GLDevice::set_default_framebuffer()

### DIFF
--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -42,6 +42,10 @@ impl GLDevice {
         }
     }
 
+    pub fn set_default_framebuffer(&mut self, framebuffer: GLuint) {
+        self.default_framebuffer = framebuffer;
+    }
+
     fn set_texture_parameters(&self, texture: &GLTexture) {
         self.bind_texture(texture, 0);
         unsafe {


### PR DESCRIPTION
Okay, I have no idea if this PR contains the right kind of change for pathfinder, but I figured it'd start a conversation, at least.

Basically, when addressing the problem of dynamically resizing the in-editor Unity player mentioned in https://github.com/pcwalton/pathfinder/issues/147#issuecomment-496015315 (e.g., when the user clicks "play" and then resizes their window), I found that the approach used in Pathfinder's demo code didn't fully work in Unity:

https://github.com/pcwalton/pathfinder/blob/bc713a5181ab7ed90469d054c36f78baed36b306/demo/common/src/lib.rs#L266-L274

Specifically, what happens is that the Pathfinder rendering simply disappears every time I resize the window, though it occasionally/randomly comes back into view.  I tried simply re-instantiating the whole `Renderer` instance every time the window is resized, and while it did fix the problem, it was also very slow and made resizing the Unity window quite sluggish.

After some diagnosis I noticed that Unity appears to change the current GL framebuffer when the user resizes the window; I think the reason the rendering randomly re-appeared on resize was because eventually Unity would happen to use the same framebuffer ID that I'd initialized the renderer with.

However, I also found that if I'm able to _change_ the `GLDevice` that Pathfinder is using to reflect the new framebuffer ID, everything seems to work fine.  There isn't currently a way to do that, however, so this PR adds a simple accessor method that makes it possible.  But I'm not sure if this violates encapsulation in some way, or has other consequences that I'm not aware of.

For reference, the experimental Unity Plugin code that uses this accessor method is at https://github.com/toolness/pathfinder-unity-fun/commit/39221cf7b9bf7d5aba77cc4f7dcae91586eb8040.

@pcwalton do you have thoughts on this?
