### PR TITLE
Fix unused variable warning

### DIFF
--- a/gl/src/lib.rs
+++ b/gl/src/lib.rs
@@ -271,7 +271,7 @@ impl Device for GLDevice {
     }
 
     fn create_program_from_shaders(&self,
-                                   resources: &dyn ResourceLoader,
+                                   _resources: &dyn ResourceLoader,
                                    name: &str,
                                    vertex_shader: GLShader,
                                    fragment_shader: GLShader)


### PR DESCRIPTION
Fixing the following warning
warning: unused variable: `resources`

Small but I saw this warning will starting to write tests.