### PR TITLE
Add test_i32x4_swizzles

### DIFF
--- a/simd/src/test.rs
+++ b/simd/src/test.rs
@@ -385,3 +385,12 @@ fn test_i32x4_packed_comparisons() {
     let b = I32x4::new(-59, 1, 5, 104);
     assert_eq!(a.packed_eq(b), U32x4::new(0, !0, !0, 0));
 }
+
+#[test]
+fn test_i32x4_swizzles() {
+    let a = I32x4::new(1, 2, 3, 4);
+    assert_eq!(a.xyxy(), I32x4::new(1, 2, 1, 2));
+    assert_eq!(a.xwzy(), I32x4::new(1, 4, 3, 2));
+    assert_eq!(a.zyxw(), I32x4::new(3, 2, 1, 4));
+    assert_eq!(a.zwxy(), I32x4::new(3, 4, 1, 2));
+}


### PR DESCRIPTION
This raises the test coverage in SIMD from 10.04% to 10.27%, just a bit.

@pcwalton, I see there is a comment about completing I32x4 swizzles, do you want me to do that? In this commit I'm only testing the 4 that exist.